### PR TITLE
power button: only respond to release signal

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -75,14 +75,8 @@ Item {
 		property bool ignoreRelease: false
 		
 		onKey: (key) => {
-			if (ignoreRelease) {
-				ignoreRelease = false;
-				return;
-			}
-
-			if (key == CutieWlc.PowerPress && !outputPowerManager.mode) {
+			if (key == CutieWlc.PowerRelease && !outputPowerManager.mode) {
 				outputPowerManager.mode = true;
-				ignoreRelease = true;
 				relockTimer.start();
 			} else if (key == CutieWlc.PowerRelease && outputPowerManager.mode) {
 				outputPowerManager.mode = false;


### PR DESCRIPTION
cutie panel responding to both pressed and released signals causes issues on some devices.
 This change limit the response to released signal.
 This reduces 5 lines of code.